### PR TITLE
Fix parsing of pinned locales with comma-separated names

### DIFF
--- a/app/src/main/java/vegabobo/languageselector/ui/screen/appinfo/AppInfoVm.kt
+++ b/app/src/main/java/vegabobo/languageselector/ui/screen/appinfo/AppInfoVm.kt
@@ -160,8 +160,14 @@ fun Set<String>.parseSetLangs(): MutableList<SingleLocale> {
     return this.mapNotNull {
         try {
             val stringLocale = it.split(",")
-            val name = stringLocale[0]
-            val tag = stringLocale[1]
+            if (stringLocale.size < 2) {
+                throw IllegalArgumentException("Invalid locale entry: $it")
+            }
+            val tag = stringLocale.last().trim()
+            val name = stringLocale
+                .dropLast(1)
+                .joinToString(",")
+                .trim()
             SingleLocale(name, tag)
         } catch (e: Exception) {
             Log.e(BuildConfig.APPLICATION_ID, e.stackTraceToString())

--- a/app/src/test/java/vegabobo/languageselector/ui/screen/appinfo/ParseSetLangsTest.kt
+++ b/app/src/test/java/vegabobo/languageselector/ui/screen/appinfo/ParseSetLangsTest.kt
@@ -1,0 +1,29 @@
+package vegabobo.languageselector.ui.screen.appinfo
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ParseSetLangsTest {
+
+    @Test
+    fun `parseSetLangs returns single locale without commas`() {
+        val set = setOf("English,en")
+
+        val locales = set.parseSetLangs()
+
+        assertEquals(1, locales.size)
+        assertEquals("English", locales[0].name)
+        assertEquals("en", locales[0].languageTag)
+    }
+
+    @Test
+    fun `parseSetLangs preserves names containing commas`() {
+        val set = setOf("Portuguese, Brazil,pt-BR")
+
+        val locales = set.parseSetLangs()
+
+        assertEquals(1, locales.size)
+        assertEquals("Portuguese, Brazil", locales[0].name)
+        assertEquals("pt-BR", locales[0].languageTag)
+    }
+}


### PR DESCRIPTION
## Summary
- adjust parseSetLangs to rebuild locale names when the stored value contains additional commas
- trim parsed names/tags and keep the existing storage format used by onPinLang
- add unit coverage to ensure names containing commas are restored correctly

## Testing
- ./gradlew test *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e52cc5888323ae60f2de58ce360d