### PR TITLE
Update app type labels

### DIFF
--- a/app/src/main/java/vegabobo/languageselector/ui/components/AppListItem.kt
+++ b/app/src/main/java/vegabobo/languageselector/ui/components/AppListItem.kt
@@ -18,10 +18,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.drawable.toBitmap
+import vegabobo.languageselector.R
 import vegabobo.languageselector.ui.screen.main.AppInfo
 
 @Composable
@@ -49,7 +51,12 @@ fun AppListItem(
             Text(text = app.name, fontSize = 18.sp, fontWeight = FontWeight.Medium, maxLines = 1)
             Text(text = app.pkg, fontSize = 12.sp, maxLines = 1)
             Row {
-                TextLabel(text = if (app.isSystemApp()) "System App" else "User App")
+                val appTypeLabel = if (app.isSystemApp()) {
+                    stringResource(id = R.string.system_app_label)
+                } else {
+                    stringResource(id = R.string.user_app_label)
+                }
+                TextLabel(text = appTypeLabel)
                 if (app.isModified())
                     TextLabel(text = "Modified")
             }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -9,6 +9,8 @@
     <string name="all_languages">すべての言語:</string>
     <string name="show_only_user_apps">ユーザーアプリのみを表示</string>
     <string name="show_system_apps">システムアプリを表示</string>
+    <string name="system_app_label">システム</string>
+    <string name="user_app_label">ユーザー</string>
     <string name="settings">設定</string>
     <string name="open">開く</string>
     <string name="close">閉じる</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -9,6 +9,8 @@
     <string name="all_languages">Todos os idiomas:</string>
     <string name="show_only_user_apps">Mostrar apenas apps do usuário</string>
     <string name="show_system_apps">Mostrar apps do sistema</string>
+    <string name="system_app_label">Sistema</string>
+    <string name="user_app_label">Usuário</string>
     <string name="settings">Config.</string>
     <string name="open">Abrir</string>
     <string name="close">Fechar</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -8,6 +8,8 @@
     <string name="all_languages">全部语言:</string>
     <string name="show_only_user_apps">只显示用户应用</string>
     <string name="show_system_apps">显示系统应用</string>
+    <string name="system_app_label">系统</string>
+    <string name="user_app_label">用户</string>
     <string name="settings">设置</string>
     <string name="open">打开</string>
     <string name="close">关闭</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
     <string name="all_languages">All languages:</string>
     <string name="show_only_user_apps">Show only user apps</string>
     <string name="show_system_apps">Show system apps</string>
+    <string name="system_app_label">System</string>
+    <string name="user_app_label">User</string>
     <string name="settings">Settings</string>
     <string name="open">Open</string>
     <string name="close">Close</string>


### PR DESCRIPTION
## Summary
- replace the app type badge copy with the new "System" and "User" labels
- add localized string resources for the new labels in every supported locale

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e756349483239ed71fd0b901dfee