### PR TITLE
Configure release signing keystore

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -42,6 +42,30 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Restore release keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          if [ -z "${ANDROID_KEYSTORE_BASE64}" ]; then
+            echo "Missing ANDROID_KEYSTORE_BASE64 secret" >&2
+            exit 1
+          fi
+
+          echo "Restoring release.keystore"
+          echo "${ANDROID_KEYSTORE_BASE64}" | base64 --decode > "${HOME}/release.keystore"
+          chmod 600 "${HOME}/release.keystore"
+
+          {
+            echo "RELEASE_STORE_FILE=${HOME}/release.keystore"
+            echo "ANDROID_KEYSTORE_PATH=${HOME}/release.keystore"
+            echo "RELEASE_STORE_PASSWORD=${ANDROID_KEYSTORE_PASSWORD}"
+            echo "RELEASE_KEY_ALIAS=${ANDROID_KEY_ALIAS}"
+            echo "RELEASE_KEY_PASSWORD=${ANDROID_KEY_PASSWORD}"
+          } >> "${GITHUB_ENV}"
+
       - name: Build release APK
         run: ./gradlew assembleRelease
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ You can get this app at Releases section.
 <img src="https://raw.githubusercontent.com/VegaBobo/Language-Selector/main/other/preview_2.jpg" alt="preview" width="200"/>
 </div>
 
+### Release signing configuration
+
+The CI pipeline expects the release keystore and credentials to be supplied via GitHub Actions secrets:
+
+- `ANDROID_KEYSTORE_BASE64`: Base64-encoded contents of the release keystore.
+- `ANDROID_KEYSTORE_PASSWORD`: Password used to protect the keystore file.
+- `ANDROID_KEY_ALIAS`: Alias of the signing key inside the keystore.
+- `ANDROID_KEY_PASSWORD`: Password for the signing key.
+
+During the `release-build` workflow these secrets are restored into a `release.keystore` file and exported as environment variables that Gradle consumes while building the release variant. For local builds you can either export the same environment variables or declare the following properties in your `~/.gradle/gradle.properties` (or the project’s `gradle.properties` which should remain untracked):
+
+```
+RELEASE_STORE_FILE=/absolute/path/to/release.keystore
+RELEASE_STORE_PASSWORD=your-keystore-password
+RELEASE_KEY_ALIAS=your-key-alias
+RELEASE_KEY_PASSWORD=your-key-password
+```
+
+With those values configured, running `./gradlew assembleRelease` will use the dedicated release keystore instead of the debug signing configuration.
+
 ### Features
 
 - Set individual app languages

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,25 @@ android {
     namespace = "vegabobo.languageselector"
     compileSdk = 35
 
+    signingConfigs {
+        create("release") {
+            val keystorePath: String? = providers.gradleProperty("RELEASE_STORE_FILE").orNull
+                ?: System.getenv("RELEASE_STORE_FILE")
+                ?: System.getenv("ANDROID_KEYSTORE_PATH")
+            val storePasswordValue: String? = providers.gradleProperty("RELEASE_STORE_PASSWORD").orNull
+                ?: System.getenv("RELEASE_STORE_PASSWORD")
+            val keyAliasValue: String? = providers.gradleProperty("RELEASE_KEY_ALIAS").orNull
+                ?: System.getenv("RELEASE_KEY_ALIAS")
+            val keyPasswordValue: String? = providers.gradleProperty("RELEASE_KEY_PASSWORD").orNull
+                ?: System.getenv("RELEASE_KEY_PASSWORD")
+
+            keystorePath?.let { storeFile = file(it) }
+            storePasswordValue?.let { storePassword = it }
+            keyAliasValue?.let { keyAlias = it }
+            keyPasswordValue?.let { keyPassword = it }
+        }
+    }
+
     defaultConfig {
         applicationId = "vegabobo.languageselector"
         minSdk = 33
@@ -26,7 +45,7 @@ android {
 
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(


### PR DESCRIPTION
## Summary
- restore the release keystore from GitHub Actions secrets during the release workflow and expose the credentials for Gradle
- configure the release build type to use a dedicated signingConfig fed by environment or Gradle properties
- document how to provide the keystore credentials locally and in CI

## Testing
- ⚠️ `./gradlew assembleDebug` *(fails: Android SDK not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da9912aca8832394fc4f8081dfeaa4