### PR TITLE
Refresh Chinese locale strings

### DIFF
--- a/app/src/main/java/vegabobo/languageselector/ui/components/AppListItem.kt
+++ b/app/src/main/java/vegabobo/languageselector/ui/components/AppListItem.kt
@@ -58,7 +58,7 @@ fun AppListItem(
                 }
                 TextLabel(text = appTypeLabel)
                 if (app.isModified())
-                    TextLabel(text = "Modified")
+                    TextLabel(text = stringResource(id = R.string.label_modified))
             }
         }
     }

--- a/app/src/main/java/vegabobo/languageselector/ui/components/AppSearchBar.kt
+++ b/app/src/main/java/vegabobo/languageselector/ui/components/AppSearchBar.kt
@@ -92,7 +92,7 @@ fun AppSearchBar(
                             .horizontalScroll(rememberScrollState())
                     ) {
                         FilterLabel(
-                            title = "Show System",
+                            title = stringResource(id = R.string.filter_show_system),
                             onClick = {
                                 onSelectedLabelsChange(AppLabels.SYSTEM_APP)
                             },
@@ -100,7 +100,7 @@ fun AppSearchBar(
                         )
                         Spacer(Modifier.padding(8.dp))
                         FilterLabel(
-                            title = "Show Modified",
+                            title = stringResource(id = R.string.filter_show_modified),
                             onClick = { onSelectedLabelsChange(AppLabels.MODIFIED) },
                             isSelected = selectedLabels.contains(AppLabels.MODIFIED)
                         )
@@ -141,7 +141,7 @@ fun AppSearchBar(
                         horizontalArrangement = Arrangement.Center
                     ) {
                         Text(
-                            text = "History".uppercase(),
+                            text = stringResource(id = R.string.search_history_title).uppercase(),
                             fontSize = 14.sp,
                             fontWeight = FontWeight.Medium,
                             letterSpacing = 1.sp,
@@ -157,7 +157,7 @@ fun AppSearchBar(
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.Center
                             ) {
-                                Text(text = "Clear")
+                                Text(text = stringResource(id = R.string.search_history_clear))
                             }
                         }
                         Spacer(modifier = Modifier.padding(6.dp))

--- a/app/src/main/java/vegabobo/languageselector/ui/screen/main/MainScreen.kt
+++ b/app/src/main/java/vegabobo/languageselector/ui/screen/main/MainScreen.kt
@@ -41,6 +41,9 @@ fun MainScreen(
     val uiState by mainScreenVm.uiState.collectAsState()
     val sb = remember { SnackbarHostState() }
     val lazyListState = rememberLazyListState()
+    val modifiedMovedUpMessage = stringResource(id = R.string.snackbar_modified_moved_up)
+    val unmodifiedMovedDownMessage = stringResource(id = R.string.snackbar_unmodified_moved_down)
+    val navigateActionLabel = stringResource(id = R.string.snackbar_action_navigate)
 
     LaunchedEffect(Unit) {
         mainScreenVm.reloadLastSelectedItem()
@@ -48,8 +51,8 @@ fun MainScreen(
             when (it.snackBarDisplay) {
                 SnackBarDisplay.MOVED_TO_TOP -> {
                     val r = sb.showSnackbar(
-                        message = "Modified app has been moved up",
-                        actionLabel = "Navigate"
+                        message = modifiedMovedUpMessage,
+                        actionLabel = navigateActionLabel
                     )
                     if (r == SnackbarResult.ActionPerformed) {
                         val i =
@@ -60,8 +63,8 @@ fun MainScreen(
 
                 SnackBarDisplay.MOVED_TO_BOTTOM -> {
                     val r = sb.showSnackbar(
-                        message = "Unmodified has been moved down",
-                        actionLabel = "Navigate"
+                        message = unmodifiedMovedDownMessage,
+                        actionLabel = navigateActionLabel
                     )
                     if (r == SnackbarResult.ActionPerformed) {
                         val i =

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_language">App语言</string>
+    <string name="app_language">应用语言</string>
     <string name="system_default">系统默认</string>
-    <string name="user_languages">用户语言</string>
-    <string name="pinned">置顶:</string>
-    <string name="region">地区:</string>
-    <string name="all_languages">全部语言:</string>
-    <string name="show_only_user_apps">只显示用户应用</string>
+    <string name="user_languages">用户语言：</string>
+    <string name="pinned">置顶：</string>
+    <string name="region">地区：</string>
+    <string name="all_languages">全部语言：</string>
+    <string name="show_only_user_apps">仅显示用户应用</string>
     <string name="show_system_apps">显示系统应用</string>
     <string name="system_app_label">系统</string>
     <string name="user_app_label">用户</string>
@@ -14,19 +14,31 @@
     <string name="open">打开</string>
     <string name="close">关闭</string>
     <string name="permissions_required">需要权限</string>
-    <string name="shizuku_required">该应用需要 Shizuku,请安装并启动 Shizuku,获得 Shizuku 权限后,你可以继续</string>
+    <string name="shizuku_required">此应用需要 Shizuku，请安装并启动 Shizuku，授予 Shizuku 权限后即可继续。</string>
     <string name="proceed">继续</string>
     <string name="pinned_ok">%1$s 已置顶</string>
-    <string name="unpinned">%1$s 取消置顶</string>
+    <string name="unpinned">%1$s 已取消置顶</string>
     <string name="about">关于</string>
-    <string name="deps_libs">依赖库信息:</string>
-    <string name="version">版本 %1$s (%2$s)</string>
+    <string name="deps_libs">依赖和库信息：</string>
+    <string name="version">版本 %1$s（%2$s）</string>
     <string name="app">应用</string>
-    <string name="ghrepo">Github 仓库</string>
-    <string name="view_source">查看源码</string>
-    <string name="loading">加载中...</string>
+    <string name="ghrepo">GitHub 仓库</string>
+    <string name="view_source">查看源代码</string>
+    <string name="loading">加载中…</string>
     <string name="unavailable">不可用</string>
     <string name="warning">警告</string>
-    <string name="warning_system_apps">不建议对系统应用选择语言,你确定?</string>
+    <string name="warning_system_apps">不建议为系统应用选择语言，你确定吗？</string>
     <string name="cancel">取消</string>
+
+    <string name="search">搜索应用</string>
+    <string name="search_no_results">未找到结果</string>
+    <string name="search_start_typing">输入内容以开始搜索</string>
+    <string name="filter_show_system">显示系统</string>
+    <string name="filter_show_modified">显示已修改</string>
+    <string name="search_history_title">历史记录</string>
+    <string name="search_history_clear">清除</string>
+    <string name="label_modified">已修改</string>
+    <string name="snackbar_modified_moved_up">已修改的应用已移到上方</string>
+    <string name="snackbar_unmodified_moved_down">未修改的应用已移到下方</string>
+    <string name="snackbar_action_navigate">前往</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_language">應用程式語言</string>
     <string name="system_default">系統預設</string>
-    <string name="user_languages">使用者語言</string>
+    <string name="user_languages">使用者語言：</string>
     <string name="pinned">已釘選：</string>
     <string name="region">地區：</string>
     <string name="all_languages">所有語言：</string>
@@ -14,19 +14,31 @@
     <string name="open">開啟</string>
     <string name="close">關閉</string>
     <string name="permissions_required">需要權限</string>
-    <string name="shizuku_required">此應用程式需要 Shizuku，請安裝並啟動 Shizuku，取得 Shizuku 權限後即可繼續</string>
+    <string name="shizuku_required">此應用程式需要 Shizuku，請安裝並啟動 Shizuku，授予 Shizuku 權限後即可繼續。</string>
     <string name="proceed">繼續</string>
     <string name="pinned_ok">%1$s 已釘選</string>
     <string name="unpinned">%1$s 已取消釘選</string>
     <string name="about">關於</string>
     <string name="deps_libs">相依程式庫資訊：</string>
-    <string name="version">版本 %1$s (%2$s)</string>
+    <string name="version">版本 %1$s（%2$s）</string>
     <string name="app">應用程式</string>
-    <string name="ghrepo">Github 儲存庫</string>
+    <string name="ghrepo">GitHub 儲存庫</string>
     <string name="view_source">檢視原始碼</string>
-    <string name="loading">載入中...</string>
+    <string name="loading">載入中…</string>
     <string name="unavailable">無法使用</string>
     <string name="warning">警告</string>
-    <string name="warning_system_apps">不建議對系統應用程式選擇語言，您確定要繼續嗎？</string>
+    <string name="warning_system_apps">不建議為系統應用程式選擇語言，您確定要繼續嗎？</string>
     <string name="cancel">取消</string>
+
+    <string name="search">搜尋應用程式</string>
+    <string name="search_no_results">找不到符合的結果</string>
+    <string name="search_start_typing">輸入內容即可開始搜尋</string>
+    <string name="filter_show_system">顯示系統</string>
+    <string name="filter_show_modified">顯示已修改</string>
+    <string name="search_history_title">歷史記錄</string>
+    <string name="search_history_clear">清除</string>
+    <string name="label_modified">已修改</string>
+    <string name="snackbar_modified_moved_up">已修改的應用程式已移到上方</string>
+    <string name="snackbar_unmodified_moved_down">未修改的應用程式已移到下方</string>
+    <string name="snackbar_action_navigate">前往</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,12 @@
     <string name="search">Search apps</string>
     <string name="search_no_results">No results found</string>
     <string name="search_start_typing">Type something to search</string>
+    <string name="filter_show_system">Show system</string>
+    <string name="filter_show_modified">Show modified</string>
+    <string name="search_history_title">History</string>
+    <string name="search_history_clear">Clear</string>
+    <string name="label_modified">Modified</string>
+    <string name="snackbar_modified_moved_up">Modified app has been moved up</string>
+    <string name="snackbar_unmodified_moved_down">Unmodified has been moved down</string>
+    <string name="snackbar_action_navigate">Navigate</string>
 </resources>


### PR DESCRIPTION
## Summary
- polish the Simplified Chinese strings with improved wording and punctuation
- align the Traditional Chinese translations and add the missing search-related strings
- move remaining hardcoded labels (e.g., Modified, History) into string resources and translate them

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ef32a59f6483239feb12890f1b3f2f