### PR TITLE
Use fixed colors for app labels

### DIFF
--- a/app/src/main/java/vegabobo/languageselector/ui/components/AppListItem.kt
+++ b/app/src/main/java/vegabobo/languageselector/ui/components/AppListItem.kt
@@ -11,12 +11,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -25,6 +25,13 @@ import androidx.compose.ui.unit.sp
 import androidx.core.graphics.drawable.toBitmap
 import vegabobo.languageselector.R
 import vegabobo.languageselector.ui.screen.main.AppInfo
+
+private val SystemLabelBackground = Color(0xFFE0E0E0)
+private val SystemLabelContent = Color(0xFF424242)
+private val UserLabelBackground = Color(0xFFBBDEFB)
+private val UserLabelContent = Color(0xFF0D47A1)
+private val ModifiedLabelBackground = Color(0xFFFFE0B2)
+private val ModifiedLabelContent = Color(0xFFE65100)
 
 @Composable
 fun AppListItem(
@@ -51,33 +58,55 @@ fun AppListItem(
             Text(text = app.name, fontSize = 18.sp, fontWeight = FontWeight.Medium, maxLines = 1)
             Text(text = app.pkg, fontSize = 12.sp, maxLines = 1)
             Row {
-                val appTypeLabel = if (app.isSystemApp()) {
-                    stringResource(id = R.string.system_app_label)
+                val (appTypeLabel, appTypeBackground, appTypeContent) = if (app.isSystemApp()) {
+                    Triple(
+                        stringResource(id = R.string.system_app_label),
+                        SystemLabelBackground,
+                        SystemLabelContent
+                    )
                 } else {
-                    stringResource(id = R.string.user_app_label)
+                    Triple(
+                        stringResource(id = R.string.user_app_label),
+                        UserLabelBackground,
+                        UserLabelContent
+                    )
                 }
-                TextLabel(text = appTypeLabel)
-                if (app.isModified())
-                    TextLabel(text = stringResource(id = R.string.label_modified))
+                TextLabel(
+                    text = appTypeLabel,
+                    backgroundColor = appTypeBackground,
+                    contentColor = appTypeContent
+                )
+                if (app.isModified()) {
+                    TextLabel(
+                        text = stringResource(id = R.string.label_modified),
+                        backgroundColor = ModifiedLabelBackground,
+                        contentColor = ModifiedLabelContent
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-fun TextLabel(text: String) {
+fun TextLabel(
+    text: String,
+    backgroundColor: Color,
+    contentColor: Color
+) {
     Box(Modifier.padding(top = 2.dp, end = 4.dp, bottom = 4.dp)) {
         Box(
             Modifier
                 .clip(RoundedCornerShape(8.dp))
-                .background(MaterialTheme.colorScheme.onPrimary)
+                .background(backgroundColor)
         ) {
             Text(
                 modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 2.dp, bottom = 2.dp),
                 text = text,
                 maxLines = 1,
                 lineHeight = 16.sp,
-                fontSize = 10.sp
+                fontSize = 10.sp,
+                color = contentColor
             )
         }
     }


### PR DESCRIPTION
## Summary
- replace app label styling to use fixed color constants for each label type
- remove dependence on MaterialTheme for label rendering and apply explicit colors for system, user, and modified tags

## Testing
- ./gradlew test *(fails: Android SDK not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6905a54a5a588323acf286014441833f